### PR TITLE
ModuleManager fixes / improvements

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/KamiMod.java
+++ b/src/main/java/me/zeroeightsix/kami/KamiMod.java
@@ -130,7 +130,8 @@ public class KamiMod {
         loadConfiguration();
         KamiMod.log.info("Settings loaded");
 
-        ModuleManager.updateLookup(); // generate the lookup table after settings are loaded to make custom module names work
+        // custom names aren't known at compile-time
+        //ModuleManager.updateLookup(); // generate the lookup table after settings are loaded to make custom module names work
 
         new Capes();
         KamiMod.log.info("Capes init!\n");

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/DisplayGuiScreen.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/DisplayGuiScreen.java
@@ -9,7 +9,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.shader.Framebuffer;
-import net.minecraft.launchwrapper.LogWrapper;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 

--- a/src/main/java/me/zeroeightsix/kami/module/Module.java
+++ b/src/main/java/me/zeroeightsix/kami/module/Module.java
@@ -4,7 +4,6 @@ import com.google.common.base.Converter;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import me.zeroeightsix.kami.KamiMod;
-import me.zeroeightsix.kami.event.events.PacketEvent;
 import me.zeroeightsix.kami.event.events.RenderEvent;
 import me.zeroeightsix.kami.setting.Setting;
 import me.zeroeightsix.kami.setting.Settings;

--- a/src/main/java/me/zeroeightsix/kami/module/ModuleManager.java
+++ b/src/main/java/me/zeroeightsix/kami/module/ModuleManager.java
@@ -34,7 +34,7 @@ public class ModuleManager {
     public static void updateLookup() {
         lookup.clear();
         for (int i = 0; i < modules.size(); i++) {
-            lookup.put(modules.get(i).getOriginalName(), i);
+            lookup.put(modules.get(i).getOriginalName().toLowerCase(), i);
         }
     }
 


### PR DESCRIPTION
custom module names aren't known as compile-time, so if a user renamed "Freecam" to "Spectator", or something similar, the lookup map would surely map "Spectator" to the "Freecam" module, but the code still asks ModuleManager for "Freecam" regardless.